### PR TITLE
feat: update firewall_policy_id handling and add validation for groups

### DIFF
--- a/modules/collection-rule-groups/main.tf
+++ b/modules/collection-rule-groups/main.tf
@@ -6,9 +6,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "group" {
     each.value.name, format("fwrcg-%s", each.key)
   )
 
-  firewall_policy_id = try(
-    var.groups[each.key].firewall_policy_id, null
-  )
+  firewall_policy_id = coalesce(var.groups[each.key].firewall_policy_id, var.firewall_policy_id)
 
   priority = each.value.priority
 

--- a/modules/collection-rule-groups/variables.tf
+++ b/modules/collection-rule-groups/variables.tf
@@ -1,3 +1,9 @@
+variable "firewall_policy_id" {
+  description = "The ID of the Firewall Policy to which rule collection groups will be applied."
+  type        = string
+  default     = null
+}
+
 variable "groups" {
   description = "Contains all firewall policy rule collection groups config"
   type = map(object({
@@ -63,4 +69,12 @@ variable "groups" {
       }))
     })), {})
   }))
+
+  validation {
+    condition = var.firewall_policy_id != null || alltrue([
+      for group_key, group in var.groups :
+      group.firewall_policy_id != null
+    ])
+    error_message = "If the top-level firewall_policy_id is not set, each group in the groups map must have its own firewall_policy_id specified."
+  }
 }


### PR DESCRIPTION
## Description

This PR provides the ability to set a firewall_policy_id at top-level and have it overwritten at group-level. Also added validation and removed the null option (not allowed by resource).

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything)

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_firewall_policy_rule_collection_group` - support for the `firewall_policy_id` top-level property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)